### PR TITLE
Fixed a deprecated usage

### DIFF
--- a/hello.rst
+++ b/hello.rst
@@ -17,7 +17,7 @@ Running the Taichi code below (``python3 fractal.py`` or ``ti example fractal``)
     ti.init(arch=ti.gpu)
 
     n = 320
-    pixels = ti.var(dt=ti.f32, shape=(n * 2, n))
+    pixels = ti.field(dtype=float, shape=(n * 2, n))
 
 
     @ti.func


### PR DESCRIPTION
In the first program(fractal.py) showed in the chapter "Hello, World!"(hello.rst), there exist a deprecated usage of ti.var, which would cause a warning as below:
`DeprecationWarning: ti.var is deprecated. Please use ti.field instead.

  File "fractal.py", line 7, in <module>
    pixels = ti.var(dt=ti.f32, shape=(n * 2, n))`
It could be fixed as shown in this PR.